### PR TITLE
Fix/element internals support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@anypoint-web-components/anypoint-checkbox",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anypoint-web-components/anypoint-checkbox",
   "description": "Anypoint and Material DS styled checkbox",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/AnypointCheckbox.js
+++ b/src/AnypointCheckbox.js
@@ -193,7 +193,7 @@ export class AnypointCheckbox extends ButtonStateMixin(ControlStateMixin(Checked
       this.indeterminate = false;
     }
     this.setAttribute('aria-checked', value ? 'true' : 'false');
-    if (this._internals) {
+    if (this._internals && this._internals.setFormValue && this._internals.setValidity) {
       this._internals.setFormValue(value ? this.value : '');
 
       if (!this.matches(':disabled') && this.hasAttribute('required') && !value) {
@@ -216,7 +216,7 @@ export class AnypointCheckbox extends ButtonStateMixin(ControlStateMixin(Checked
   }
 
   checkValidity() {
-    if (this._internals) {
+    if (this._internals && this._internals.checkValidity) {
       return this._internals.checkValidity();
     }
     return this.required ? this.checked : true;
@@ -228,11 +228,15 @@ export class AnypointCheckbox extends ButtonStateMixin(ControlStateMixin(Checked
 
   formResetCallback() {
     this.checked = false;
-    this._internals.setFormValue('');
+    if (this._internals && this._internals.setFormValue) {
+      this._internals.setFormValue('');
+    }
   }
 
   formStateRestoreCallback(state) {
-    this._internals.setFormValue(state);
+    if (this._internals && this._internals.setFormValue) {
+      this._internals.setFormValue(state);
+    }
     this.checked = !!state;
   }
 }


### PR DESCRIPTION
Some ElementInternals methods are not supported by firefox and safari so we should check their availability before calling them.

